### PR TITLE
Pzsp2 11 stop Jenkins from pushing to the DH when not on master.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,16 @@ pipeline {
             }
             steps {
                 sh 'docker login -u $DOCKERHUB_CREDS_USR -p $DOCKERHUB_CREDS_PSW'
-                sh 'docker push $DOCKERHUB_CREDS_USR/$CONTAINER_NAME'
+                sh 'docker push $DOCKERHUB_CREDS_USR/$CONTAINER_NAME:master-latest'
+            }
+        }
+        stage('push-release') {
+            when {
+                branch 'release'
+            }
+            steps {
+                sh 'docker login -u $DOCKERHUB_CREDS_USR -p $DOCKERHUB_CREDS_PSW'
+                sh 'docker push $DOCKERHUB_CREDS_USR/$CONTAINER_NAME:latest'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,10 @@ pipeline {
                 sh 'echo "tests passed"'
             }
         }
-        stage('push') {
+        stage('push-master') {
+            when {
+                branch 'master'
+            }
             steps {
                 sh 'docker login -u $DOCKERHUB_CREDS_USR -p $DOCKERHUB_CREDS_PSW'
                 sh 'docker push $DOCKERHUB_CREDS_USR/$CONTAINER_NAME'


### PR DESCRIPTION
Jenkins stops pushing to DH when on feature branches.

There are two branches, that will result in push to the DH: master and release.

Master is intendet for developers to work with, while the release branch should be used by the client.